### PR TITLE
Current time must be set before blocking operation

### DIFF
--- a/xgb.py
+++ b/xgb.py
@@ -221,14 +221,13 @@ if __name__ == '__main__':
             print(f'cloud_energy_hashmap[{key:.2f}]={val*args.vhost_ratio}', flush=True)
         sys.exit(0)
 
-
+    current_time = time.time_ns()
     for line in input_source:
         utilization = float(line.strip())
         if utilization < 0 or utilization > 100:
             raise ValueError("Utilization can not be over 100%. If you have multiple CPU cores please divide by cpu count.")
 
         if args.energy:
-            current_time = time.time_ns()
             print(interpolated_predictions[utilization] * args.vhost_ratio * \
                 (time.time_ns() - current_time) / 1_000_000_000, flush=True)
             current_time = time.time_ns()


### PR DESCRIPTION
This fixed a bug introduced in https://github.com/green-coding-solutions/cloud-energy/commit/5557f3d6939ef19d5051b395463898c258228642

The timing for energy budgeting must be set before the stream blocking call. Somehow it got mixed in the parts down below.
