### PR TITLE
Reducing requirements size

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,1 @@
 optuna==4.0.0
-scikit-learn==1.5.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+optuna==4.0.0
+scikit-learn==1.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ xgboost-cpu==2.1.1; platform_machine == "x86_64"
 xgboost==2.1.1; platform_machine != "x86_64"
 psutil==6.0.0
 pyarrow==17.0.0
+scikit-learn==1.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 numpy==2.1.1
-optuna==4.0.0
 pandas==2.2.3
-xgboost==2.1.1
+xgboost-cpu==2.1.1; platform_machine == "x86_64"
+xgboost==2.1.1; platform_machine != "x86_64"
 psutil==6.0.0
 pyarrow==17.0.0
-scikit-learn==1.5.2


### PR DESCRIPTION
The packages for scipy and xgboost are really absurd in size.

Even after trying to compile them [manually with flags](https://towardsdatascience.com/how-to-shrink-numpy-scipy-pandas-and-matplotlib-for-your-data-product-4ec8d7e86ee4) no real reduction is size was possible.

This is the remainder of the effots. Reducing XGBoost from 120 MB to 12 MB on linux and als moving all non needed packages for pure runtime to the -dex.txt
