### PR TITLE
Refactor xgboost dependencies for platform compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,9 +5,9 @@ pyarrow==24.0.0
 scikit-learn==1.9.0
 
 # Use xgboost-cpu on Linux or Windows x86_64
-xgboost-cpu==3.3.0; sys_platform == "linux" and platform_machine == "x86_64"
-xgboost-cpu==3.2.0; sys_platform == "win32" and platform_machine == "x86_64"
+xgboost-cpu==3.3.0; platform_machine == "x86_64" and (sys_platform == "linux" or sys_platform == "win32")
 
 # Use xgboost on all other platforms (e.g., macOS Intel or ARM, or non-x86_64)
-xgboost==3.3.0; sys_platform == "darwin"
-xgboost==3.2.0; platform_machine != "x86_64"
+# PEP 508 markers have no unary "not", so this is the De Morgan negation of the marker above
+# and must be kept exactly complementary to it.
+xgboost==3.3.0; platform_machine != "x86_64" or (sys_platform != "linux" and sys_platform != "win32")


### PR DESCRIPTION
Currently it fails with:

```
Collecting xgboost==3.3.0 (from -r metric_providers/psu/energy/ac/xgboost/machine/model/requirements.txt (line 12))
  Downloading xgboost-3.3.0-py3-none-macosx_12_0_arm64.whl.metadata (2.0 kB)
ERROR: Cannot install xgboost==3.2.0 and xgboost==3.3.0 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested xgboost==3.3.0
    The user requested xgboost==3.2.0
```

as on Darwin both settings hold